### PR TITLE
removed monstersLoaded from state

### DIFF
--- a/app/components/monster-details/monster-details.component.js
+++ b/app/components/monster-details/monster-details.component.js
@@ -46,6 +46,17 @@ export default function MonsterDetails({ data }) {
     },
   ];
 
+  if (data) {
+    header = (
+      <header>
+        <h1 className={style.name}>{data.name}</h1>
+        <h2 className={style.sizeTypeAlignment}>
+          {data.size} {type} {data.alignment}
+        </h2>
+      </header>
+    );
+  }
+
   if (data.subtype) {
     type = (
       <span>
@@ -107,12 +118,7 @@ export default function MonsterDetails({ data }) {
   return (
     <section className={style.monsterDetails}>
       <article>
-        <header>
-          <h1 className={style.name}>{data.name}</h1>
-          <h2 className={style.sizeTypeAlignment}>
-            {data.size} {type} {data.alignment}
-          </h2>
-        </header>
+        {header}
         {abilityScores}
         {primaryStats}
         {secondaryStats}

--- a/app/containers/monsters/monster-details/monster-details.container.js
+++ b/app/containers/monsters/monster-details/monster-details.container.js
@@ -3,6 +3,7 @@ import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 import MonsterDetails from '../../../components/monster-details/monster-details.component';
+import Spinner from '../../../components/spinner/spinner.component';
 import { loadMonsterIfNeeded } from '../../../actions/monsters.actions.js';
 
 class MonsterDetailsContainer extends Component {
@@ -11,8 +12,16 @@ class MonsterDetailsContainer extends Component {
   }
 
   render() {
-    const { monster } = this.props.monstersState;
+    const { monster, loadingMonster } = this.props.monstersState;
     let monsterToRender;
+    let spinnerToRender;
+
+    if (loadingMonster) {
+      spinnerToRender = (
+        <Spinner />
+      );
+    }
+
     if (monster) {
       monsterToRender = (
         <MonsterDetails data={monster} />
@@ -20,6 +29,7 @@ class MonsterDetailsContainer extends Component {
     }
     return (
       <div>
+        {spinnerToRender}
         {monsterToRender}
       </div>
     );

--- a/app/reducers/monsters.reducer.js
+++ b/app/reducers/monsters.reducer.js
@@ -9,9 +9,7 @@ import {
 
 const initialState = {
   loadingMonsters: false,
-  monstersLoaded: false,
   loadingMonster: false,
-  monsterLoaded: false,
   monsters: [],
   monster: {},
   error: null,
@@ -22,21 +20,18 @@ export default function monstersReducer(state = initialState, action) {
     case LOADING_MONSTERS_INITIATED:
       return Object.assign({}, state, {
         loadingMonsters: true,
-        monstersLoaded: false,
         monsters: [],
         error: null,
       });
     case LOADING_MONSTERS_SUCCESS:
       return Object.assign({}, state, {
         loadingMonsters: false,
-        monstersLoaded: true,
         monsters: action.monsters,
         error: null,
       });
     case LOADING_MONSTERS_ERROR:
       return Object.assign({}, state, {
         loadingMonsters: false,
-        monstersLoaded: false,
         monsters: [],
         error: action.error,
       });
@@ -44,21 +39,18 @@ export default function monstersReducer(state = initialState, action) {
     case LOADING_MONSTER_INITIATED:
       return Object.assign({}, state, {
         loadingMonster: true,
-        monsterLoaded: false,
         monster: {},
         error: null,
       });
     case LOADING_MONSTER_SUCCESS:
       return Object.assign({}, state, {
         loadingMonster: false,
-        monsterLoaded: true,
         monster: action.monster,
         error: null,
       });
     case LOADING_MONSTER_ERROR:
       return Object.assign({}, state, {
         loadingMonster: false,
-        monsterLoaded: false,
         monster: {},
         error: action.error,
       });

--- a/test/app/reducers/monster.reducer.test.js
+++ b/test/app/reducers/monster.reducer.test.js
@@ -10,9 +10,7 @@ describe('monsters reducer', () => {
   it('should have correct initial state', () => {
     should(reducer(undefined, {})).deepEqual({
       loadingMonsters: false,
-      monstersLoaded: false,
       loadingMonster: false,
-      monsterLoaded: false,
       monsters: [],
       monster: {},
       error: null,
@@ -32,9 +30,7 @@ describe('monsters reducer', () => {
         })
       ).deepEqual({
         loadingMonsters: true,
-        monstersLoaded: false,
         loadingMonster: false,
-        monsterLoaded: false,
         monsters: [],
         monster: {},
         error: null,
@@ -49,9 +45,7 @@ describe('monsters reducer', () => {
         })
       ).deepEqual({
         loadingMonsters: false,
-        monstersLoaded: true,
         loadingMonster: false,
-        monsterLoaded: false,
         monsters: [{ a: 1 }],
         monster: {},
         error: null,
@@ -66,9 +60,7 @@ describe('monsters reducer', () => {
         })
       ).deepEqual({
         loadingMonsters: false,
-        monstersLoaded: false,
         loadingMonster: false,
-        monsterLoaded: false,
         monsters: [],
         monster: {},
         error: 'KHANNNN!',
@@ -82,9 +74,7 @@ describe('monsters reducer', () => {
         })
       ).deepEqual({
         loadingMonsters: false,
-        monstersLoaded: false,
         loadingMonster: true,
-        monsterLoaded: false,
         monsters: [],
         monster: {},
         error: null,
@@ -99,9 +89,7 @@ describe('monsters reducer', () => {
         })
       ).deepEqual({
         loadingMonsters: false,
-        monstersLoaded: false,
         loadingMonster: false,
-        monsterLoaded: true,
         monsters: [],
         monster: { a: 1 },
         error: null,
@@ -116,9 +104,7 @@ describe('monsters reducer', () => {
         })
       ).deepEqual({
         loadingMonsters: false,
-        monstersLoaded: false,
         loadingMonster: false,
-        monsterLoaded: false,
         monsters: [],
         monster: {},
         error: 'KHANNNN!!',


### PR DESCRIPTION
closes #27

We do not need to keep track of monstersLoaded and monsterLoaded. We
are instead just checking if monsters and monsters are loading.
also added spinner back into the monster details half of things.