### PR TITLE
Favicons

### DIFF
--- a/app/index.tpl.html
+++ b/app/index.tpl.html
@@ -10,6 +10,12 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width,initial-scale=1">
 
+    <link rel="icon" href="http://i.imgur.com/FT1ZyVm.png" sizes="16x16">
+    <link rel="icon" href="http://i.imgur.com/bEm2KZ7.png" sizes="32x32">
+    <link rel="icon" href="http://i.imgur.com/RHeoihd.png" sizes="48x48">
+    <link rel="icon" href="http://i.imgur.com/r0acLM9.png" sizes="64x64">
+    <link rel="icon" href="http://i.imgur.com/YPwKR3N.png" sizes="128x128">
+
     <link href="https://fonts.googleapis.com/css?family=Crimson+Text|Lato:300,300i,400,700,700i" rel="stylesheet">
 </head>
 


### PR DESCRIPTION
closes #108

Adds favicons. Does not include .ico because this project doesn’t give
any hoots for non modern browsers.