### PR TITLE
chart api

### DIFF
--- a/server/api/controllers/charts.controller.js
+++ b/server/api/controllers/charts.controller.js
@@ -1,0 +1,40 @@
+import * as _ from 'lodash';
+import mongoose from 'mongoose';
+import { buildChartUI, buildChartSummaryUI } from '../../lib/charts.js';
+
+const logger = require('../../lib/logger')();
+
+const Chart = mongoose.model('Chart');
+
+export function getCharts(req, res) {
+  Chart
+  .find()
+  .lean()
+  .exec((err, charts) => {
+    if (!err) {
+      logger.log(`getCharts: charts.length: ${charts.length}`);
+      const chartsUI = _.map(charts, chart => (buildChartSummaryUI(chart)));
+      return res.send(chartsUI);
+    }
+    logger.log('getCharts Error: %j', err);
+    return res.send(err);
+  });
+}
+
+export function getChart(req, res) {
+  const { id } = req.params;
+
+  Chart
+  .findById(id)
+  .lean()
+  .exec((err, chart) => {
+    if (!err) {
+      const sample = _.sample(chart.chart);
+      const chartUI = buildChartUI(chart, sample);
+      logger.log('getChart: %j', chartUI.meta);
+      return res.send(chartUI);
+    }
+    logger.log('getChart Error: %j', err);
+    return res.send(err);
+  });
+}

--- a/server/api/routes/charts.route.js
+++ b/server/api/routes/charts.route.js
@@ -1,0 +1,9 @@
+import {
+  getCharts,
+  getChart,
+} from '../controllers/charts.controller';
+
+module.exports = (router) => {
+  router.route('/api/charts').get(getCharts);
+  router.route('/api/charts/:id').get(getChart);
+};

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -10,6 +10,7 @@ const config = {
     monsters: '/api/monsters',
     items: '/api/items',
     logs: '/api/logs',
+    charts: '/api/charts',
   },
 };
 

--- a/server/lib/charts.js
+++ b/server/lib/charts.js
@@ -1,0 +1,38 @@
+import config from '../config';
+
+const logger = require('./logger')();
+
+export function getChartsUrl() {
+  const url = `${config.api.charts}`;
+
+  logger.log(`getChartsUrl: url: ${url}`);
+  return url;
+}
+
+export function getChartUrl(id) {
+  const url = `${config.api.charts}/${id}`;
+
+  logger.log(`getChartUrl: url: ${url}`);
+  return url;
+}
+
+export function buildChartUI({ _id, meta, chart }, sample) {
+  return {
+    _id,
+    meta: {
+      ...meta,
+      length: chart.length,
+      roll: sample,
+    },
+    chart,
+  };
+}
+
+export function buildChartSummaryUI(chart) {
+  return {
+    _id: chart._id,
+    name: chart.meta.name,
+    length: chart.chart.length,
+    category: chart.meta.category,
+  };
+}

--- a/server/models/chart.model.js
+++ b/server/models/chart.model.js
@@ -1,0 +1,20 @@
+const mongoose = require('mongoose');
+
+const Schema = mongoose.Schema;
+
+const ChartSchema = new Schema({
+  meta: {
+    name: String,
+    description: String,
+    category: String,
+    type: String,
+    sources: [{
+      title: String,
+      author: String,
+      author_link: String,
+    }],
+  },
+  chart: [],
+});
+
+mongoose.model('Chart', ChartSchema, 'charts');

--- a/test/server/lib/charts.test.js
+++ b/test/server/lib/charts.test.js
@@ -1,0 +1,75 @@
+import should from 'should';
+
+
+describe('The charts lib', () => {
+  let chartsLib;
+  let CHART;
+
+  beforeEach(() => {
+    chartsLib = require('../../../server/lib/charts');
+
+    CHART = {
+      _id: '1234',
+      meta: {
+        name: 'A Chart',
+        category: 'Test',
+      },
+      chart: ['one', 'two'],
+      extra: 'forget this',
+    };
+  });
+
+  it('should exist', () => {
+    should.exist(chartsLib);
+  });
+
+  describe('getChartsUrl', () => {
+    it('should work', () => {
+      const expected = '/api/charts';
+      const actual = chartsLib.getChartsUrl();
+
+      should(expected).equal(actual);
+    });
+  });
+
+  describe('getChartUrl', () => {
+    it('should work', () => {
+      const expected = '/api/charts/1234';
+      const actual = chartsLib.getChartUrl('1234');
+
+      should(expected).equal(actual);
+    });
+  });
+
+  describe('buildChartUI', () => {
+    it('should work', () => {
+      const expected = {
+        _id: '1234',
+        meta: {
+          name: 'A Chart',
+          category: 'Test',
+          length: 2,
+          roll: 'one',
+        },
+        chart: ['one', 'two'],
+      };
+      const actual = chartsLib.buildChartUI(CHART, 'one');
+
+      should(expected).deepEqual(actual);
+    });
+  });
+
+  describe('buildChartSummaryUI', () => {
+    it('should work', () => {
+      const expected = {
+        _id: '1234',
+        name: 'A Chart',
+        length: 2,
+        category: 'Test',
+      };
+      const actual = chartsLib.buildChartSummaryUI(CHART);
+
+      should(expected).deepEqual(actual);
+    });
+  });
+});


### PR DESCRIPTION
A simple chart api. 
closes #111 

- /api/charts will output a summary of each chart in the db
- /api/charts/:id will provide full details as well as a sample roll on
the chart