### PR TITLE
no-underscore-dangle

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,10 +16,8 @@ rules:
   # this rule breaks globbing in express
   import/no-dynamic-require: 0
 
-  # this rule causes problems when dealing with external objects that contain underscores
-  # although since I am in control of external objects this need to be fixed.
-  # setting to warning for now
-  no-underscore-dangle: 1
+  # this rule ignores no-underscore-dangle for _id which mongo uses on all documents
+  no-underscore-dangle: [2, {allow: ['_id']}]
 
   # I don't know yet how to use ** properly as it breaks my functions when the linter like it.
   # Set to warning for now.

--- a/server/lib/monsters.js
+++ b/server/lib/monsters.js
@@ -16,7 +16,7 @@ export function getMonsterUrl(id) {
   return url;
 }
 
-export function _getAbilityScoreModifier(abilityScore) {
+export function getAbilityScoreModifier(abilityScore) {
   const mod = Math.floor((abilityScore - 10) / 2);
   return mod;
 }
@@ -41,32 +41,32 @@ export function buildMonsterUI(monster) {
       name: 'strength',
       abrv: 'STR',
       score: strength,
-      modifier: _getAbilityScoreModifier(strength),
+      modifier: getAbilityScoreModifier(strength),
     }, {
       name: 'dexterity',
       abrv: 'DEX',
       score: dexterity,
-      modifier: _getAbilityScoreModifier(dexterity),
+      modifier: getAbilityScoreModifier(dexterity),
     }, {
       name: 'constitution',
       abrv: 'CON',
       score: constitution,
-      modifier: _getAbilityScoreModifier(constitution),
+      modifier: getAbilityScoreModifier(constitution),
     }, {
       name: 'intelligence',
       abrv: 'INT',
       score: intelligence,
-      modifier: _getAbilityScoreModifier(intelligence),
+      modifier: getAbilityScoreModifier(intelligence),
     }, {
       name: 'wisdom',
       abrv: 'WIS',
       score: wisdom,
-      modifier: _getAbilityScoreModifier(wisdom),
+      modifier: getAbilityScoreModifier(wisdom),
     }, {
       name: 'charisma',
       abrv: 'CHA',
       score: charisma,
-      modifier: _getAbilityScoreModifier(charisma),
+      modifier: getAbilityScoreModifier(charisma),
     }],
     damage_vulnerabilities,
     damage_resistances,

--- a/test/server/lib/monsters.test.js
+++ b/test/server/lib/monsters.test.js
@@ -40,10 +40,10 @@ describe('monsters library', () => {
     });
   });
 
-  describe('_getAbilityScoreModifier', () => {
+  describe('getAbilityScoreModifier', () => {
     it('should work', () => {
       const expected = 5;
-      const actual = monstersLib._getAbilityScoreModifier(20);
+      const actual = monstersLib.getAbilityScoreModifier(20);
 
       should(expected).equal(actual);
     });


### PR DESCRIPTION
disable for _id, used by mongodb
fix elsewhere in the app where _id does not apply