### PR TITLE
Clear app state on logout

### DIFF
--- a/app/reducers/root.reducer.js
+++ b/app/reducers/root.reducer.js
@@ -1,15 +1,29 @@
 import { combineReducers } from 'redux';
 import { routerReducer as routing } from 'react-router-redux';
 
+import {
+  LOG_OUT_SUCCESS,
+} from '../constants/action-types';
+
 import authReducer from './auth.reducer';
 import historyReducer from './history.reducer';
 import itemsReducer from './items.reducer';
 import monstersReducer from './monsters.reducer';
 
-export default combineReducers({
+const appReducer = combineReducers({
   routing,
   authState: authReducer,
   historyState: historyReducer,
   itemsState: itemsReducer,
   monstersState: monstersReducer,
 });
+
+const rootReducer = (state, action) => {
+  if (action.type === LOG_OUT_SUCCESS) {
+    state = undefined; // eslint-disable-line
+  }
+
+  return appReducer(state, action);
+};
+
+export default rootReducer;


### PR DESCRIPTION
Root reducer listens for log_out_success action type and sets state to undefined before passing it of to the app reducer. Since app reducer is just combine reducers it passes undefined down to all the reducers resulting in each reducer returning it’s initial state, thus we reset app state. If we do not do this a user can logout and then navigate to routes with secure content that has been cached in state thus making the logout appear unsuccessful when in fact it was.

http://stackoverflow.com/questions/35622588/how-to-reset-the-state-of-a-redux-store