### PR TITLE
Custom httpcheck and error handle on login

### DIFF
--- a/server/api/controllers/login.controller.js
+++ b/server/api/controllers/login.controller.js
@@ -24,12 +24,12 @@ export function login(req, res) {
         });
       }
 
-      logger.log(`Error: ${err}`);
-      return res.sendStatus(401);
+      logger.log('Error: Username or email is incorrect.');
+      return res.status(401).send({ error: 'Username or email is incorrect.' });
     }
 
     logger.log(`Error: ${err}`);
-    return res.sendStatus(401);
+    return res.status(401).send({ error: err });
   });
 }
 

--- a/server/express.js
+++ b/server/express.js
@@ -32,7 +32,8 @@ app.use((err, req, res, next) => {
   if (err.name === 'UnauthorizedError') {
     return res
      .clearCookie(config.cookies.authToken)
-     .redirect('/login');
+     .redirect('/login')
+     .status(401).send({ error: 'Unauthorized' });
   }
 
   return next();

--- a/test/app/actions/login.actions.test.js
+++ b/test/app/actions/login.actions.test.js
@@ -49,7 +49,6 @@ describe('loginActions', () => {
             should(fetchUrl).equal('/api/login');
             should(fetchOptions.method).equal('POST');
             should(fetchOptions.body).equal(JSON.stringify({ email: 'a@b.com', password: 'security' }));
-
             should(actions[0].type).equal(types.LOG_IN_INITIATED);
             should(actions[1].type).equal(types.LOG_IN_SUCCESS);
             should(actions[1].user).deepEqual({ user: 123 });
@@ -58,6 +57,30 @@ describe('loginActions', () => {
           })
           .then(done)
           .catch(done);
+      });
+    });
+
+    describe('when status is 401', () => {
+      beforeEach(() => {
+        store = mockStore();
+        fetchMock.mock(LOGIN_URL, {
+          method: 'POST',
+          status: 401,
+        });
+      });
+
+      it('should dispatch properly', (done) => {
+        store.dispatch(loginActions.login({ username: 'yay', password: 'security', email: 'a@b.com' }))
+        .then(() => {
+          const actions = store.getActions();
+          should(actions.length).equal(2);
+          should(actions[0].type).equal(types.LOG_IN_INITIATED);
+          should(actions[1].type).equal(types.LOG_IN_ERROR);
+          // @todo: make dispatch proper error
+          // should(actions[1].error).equal('Incorrect email or password.');
+        })
+        .then(done)
+        .catch(done);
       });
     });
 


### PR DESCRIPTION
use custom http check and error handle on login to prevent default
behavior that doesn’t work on login. Still not quite right as
response.json throws an unexpected end of input error instead of
dispatching proper. But this is one more coat of paint.